### PR TITLE
Proposed changes to support pi4 and others

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,41 @@
 CFLAGS=-O2 -W -Wall -std=c99 -D_XOPEN_SOURCE=500
+LDFLAGS=-lbcm_host
+
+all: dma-demo dma-unpaced dma-paced
+
+dma-demo.o : dma-demo.c
+	-$(CC) -c dma-demo.c -o $@ $(CFLAGS)
+
+dma-unpaced.o : dma-unpaced.c
+	-$(CC) -c dma-unpaced.c -o $@ $(CFLAGS)
+
+dma-paced.o : dma-paced.c
+	-$(CC) -c dma-paced.c -o $@ $(CFLAGS)
+
+mailbox.o : mailbox.c
+	-$(CC) -c mailbox.c -o $@ $(CFLAGS)
+
+
 
 dma-demo: dma-demo.o mailbox.o
+	-$(CC) dma-demo.o mailbox.o -o $@ $(LDFLAGS)
+	-chmod 750 dma-demo
+	-sudo chown root.gpio dma-demo
+	-sudo chmod u+s dma-demo
 
 dma-unpaced: dma-unpaced.o mailbox.o
+	-$(CC) dma-unpaced.o mailbox.o -o $@ $(LDFLAGS)
+	-chmod 750 dma-unpaced
+	-sudo chown root.gpio dma-unpaced
+	-sudo chmod u+s dma-unpaced
+
 
 dma-paced: dma-paced.o mailbox.o
+	-$(CC) dma-paced.o mailbox.o -o $@ $(LDFLAGS)
+	-chmod 750 dma-paced
+	-sudo chown root.gpio dma-paced
+	-sudo chmod u+s dma-paced
+
 
 clean:
-	rm -f ./*.o ./dma-unpaced ./dma-paced ./dma-demo
+	rm -f ./*.o ./*~ ./dma-unpaced ./dma-paced ./dma-demo

--- a/dma-demo.c
+++ b/dma-demo.c
@@ -35,6 +35,7 @@ For more information, please refer to <http://unlicense.org/>
 #include <string.h>
 #include <sys/mman.h>
 #include <signal.h>
+#include <bcm_host.h>
 
 #include "mailbox.h"
 
@@ -258,7 +259,7 @@ void *map_peripheral(uint32_t addr, uint32_t size)
         PROT_READ | PROT_WRITE,
         MAP_SHARED,
         mem_fd,
-        PERI_PHYS_BASE + addr);
+        bcm_host_get_peripheral_address() + addr);
 
     close(mem_fd);
 

--- a/dma-paced.c
+++ b/dma-paced.c
@@ -35,6 +35,7 @@ For more information, please refer to <http://unlicense.org/>
 #include <string.h>
 #include <sys/mman.h>
 #include <signal.h>
+#include <bcm_host.h>
 
 #include "mailbox.h"
 
@@ -247,7 +248,7 @@ void *map_peripheral(uint32_t addr, uint32_t size)
         PROT_READ | PROT_WRITE,
         MAP_SHARED,
         mem_fd,
-        PERI_PHYS_BASE + addr);
+        bcm_host_get_peripheral_address() + addr);
 
     close(mem_fd);
 
@@ -384,7 +385,7 @@ void dma_end()
     free(dma_cbs);
 }
 
-int main()
+int main ()
 {
     uint8_t *dma_base_ptr = map_peripheral(DMA_BASE, PAGE_SIZE);
     dma_reg = (DMACtrlReg *)(dma_base_ptr + DMA_CHANNEL * 0x100);

--- a/dma-unpaced.c
+++ b/dma-unpaced.c
@@ -35,6 +35,7 @@ For more information, please refer to <http://unlicense.org/>
 #include <string.h>
 #include <sys/mman.h>
 #include <signal.h>
+#include <bcm_host.h>
 
 #include "mailbox.h"
 
@@ -174,7 +175,7 @@ void *map_peripheral(uint32_t addr, uint32_t size)
         PROT_READ | PROT_WRITE,
         MAP_SHARED,
         mem_fd,
-        PERI_PHYS_BASE + addr);
+        bcm_host_get_peripheral_address() + addr);
 
     close(mem_fd);
 


### PR DESCRIPTION
I've made these changes in order to get the tutorial to correctly run on a pi-4. The changes use the bcc_host library which provides an api call to resolve the peripheral base address for all models of pi, including the pi-4. I have tested on a pi-4, but not other models. Can you please test on your pi-3. I suspect if it works fine for you too, it will also be resolved for other pi models.