### PR TITLE
Improve address type clarity and semantic typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,13 +10,13 @@ I tested my code on my Raspberry Pi 3 B+, but it seems that the only difference 
 
 ## A little Background
 
-As described in [BCM2835-ARM-Peripherals](https://www.raspberrypi.org/app/uploads/2012/02/BCM2835-ARM-Peripherals.pdf) (the "*datasheet*"), There are three types of addresses in Raspberry Pi:
+As described in [BCM2835-ARM-Peripherals](https://www.raspberrypi.org/app/uploads/2012/02/BCM2835-ARM-Peripherals.pdf) (the "*datasheet*"), there are three types of memory addresses:
 
-* *ARM Virtual Address*: The address used in the [virtual address space](https://en.wikipedia.org/wiki/Virtual_address_space) of a Linux process.
 * *ARM Physical Address*: The address used when accessing physical memory. Since peripherals on BCM2835 are [memory-mapped](https://en.wikipedia.org/wiki/Memory-mapped_I/O), this address is used to access peripherals directly.
-* *Bus Address*: This is the address used by the DMA engine. A bus address is an address as seen by hardware peripherals.
+* *ARM Virtual Address*: The address used in the [virtual address space](https://en.wikipedia.org/wiki/Virtual_address_space) of a Linux process.
+* *Bus Address*: The address that hardware peripherals use to access memory. This is the address used by the DMA engine. Note that bus address `A` does not necessarily map to physical address `A`; in fact, in our case it doesn't. Linus Torvalds elaborates more on this idea [here](https://tldp.org/LDP/khg/HyperNews/get/devices/addrxlate.html).
 
-The *physical addresses* of the peripherals range from *0x3F000000* to *0x3FFFFFFF* and are mapped onto *bus address* range *0x7F000000* to *0x7FFFFFFF*. We can convert between them like this:
+The *physical addresses* of the peripherals range from *0x20000000* to *0x20FFFFFF* and are mapped onto *bus address* range *0x7E000000* to *0x7FFFFFFF*. We can convert between them like this:
 
 ``` c
 #define BUS_TO_PHYS(x) ((x) & ~0xC0000000


### PR DESCRIPTION
Hi,

Thanks for this great repo on DMA! It was fun to read.

I've made a few changes to the `README` that should clarify areas that I had to read more than once to understand. Most changes here should be benign.

However, I updated the physical and bus offset addresses to match up with the datasheet; in section 1.2.3 on ARM physical addresses (page 6), the physical offset is `0x20000000` and the bus offset is `0x7E000000`. I am a bit concerned about my change here because the code ([dma-demo.c:49](https://github.com/fandahao17/Raspberry-Pi-DMA-Tutorial/blob/master/dma-demo.c#L49)) does use `0x3F000000`; it's unclear why this works. I don't see any reference to `0x3F000000` in the datasheet, so I'm unsure what the README should actually contain.

Thanks!